### PR TITLE
Add error handling and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Smoke test CLI
-        run: python habit.py --help
+      - name: Run tests
+        run: pytest -v

--- a/habit.py
+++ b/habit.py
@@ -24,34 +24,40 @@ HABITS = {
     "yoga": "Yoga",
     "cardio": "Cardio",
     "weights": "Weights",
-    "read": "Read"
+    "read": "Read",
 }
 
 
 # Load habit data from file
-def load_data():
+def load_data() -> dict:
+    """Read the habit data JSON file if it exists."""
     if os.path.exists(DATA_FILE):
-        with open(DATA_FILE) as f:
-            return json.load(f)
+        try:
+            with open(DATA_FILE) as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            # Malformed file, start fresh
+            return {}
     return {}
 
 
 # Save habit data to file
-def save_data(data):
+def save_data(data: dict) -> None:
+    """Write habit data to the JSON file."""
     with open(DATA_FILE, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=2)
 
 
 @app.command()
-def log(habit: str, minutes: int = 1):
+def log(habit: str, minutes: int = 1) -> None:
     """
     Log a habit with optional minutes (default: 1).
     Example: python habit.py log med 5
     """
     if habit not in HABITS:
-        typer.echo(f"❌ Unknown habit key: {habit}")
-        typer.echo(f"➡️ Valid keys: {', '.join(HABITS)}")
-        raise typer.Exit()
+        raise typer.BadParameter(
+            f"Unknown habit key: {habit}. Valid keys: {', '.join(HABITS)}"
+        )
 
     data = load_data()
     today = str(datetime.date.today())
@@ -62,7 +68,7 @@ def log(habit: str, minutes: int = 1):
 
 
 @app.command()
-def mood(score: int = typer.Argument(..., min=1, max=5)):
+def mood(score: int = typer.Argument(..., min=1, max=5)) -> None:
     """
     Log today's mood on a scale from 1 to 5.
     Example: python habit.py mood 4
@@ -76,7 +82,7 @@ def mood(score: int = typer.Argument(..., min=1, max=5)):
 
 
 @app.command()
-def show():
+def show() -> None:
     """
     Show this week's habit grid with checkmarks.
     Example: python habit.py show

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 typer>=0.12
 rich>=13.7
-python-dateutil>=2.9
+pytest>=8.2

--- a/tests/test_habit.py
+++ b/tests/test_habit.py
@@ -1,0 +1,32 @@
+from typer.testing import CliRunner
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import habit
+
+runner = CliRunner()
+
+
+def test_load_data_missing_file(tmp_path):
+    """load_data should return empty dict if file doesn't exist."""
+    orig_path = habit.DATA_FILE
+    habit.DATA_FILE = tmp_path / "habit.json"
+    try:
+        assert habit.load_data() == {}
+    finally:
+        habit.DATA_FILE = orig_path
+
+
+def test_log_unknown_habit(tmp_path):
+    """`log` should error when habit key is invalid."""
+    orig_path = habit.DATA_FILE
+    habit.DATA_FILE = tmp_path / "habit.json"
+    try:
+        result = runner.invoke(habit.app, ["log", "invalid"])
+        assert result.exit_code != 0
+        assert "Unknown habit key" in (result.stderr or result.stdout)
+    finally:
+        habit.DATA_FILE = orig_path


### PR DESCRIPTION
## Summary
- handle malformed JSON when loading data
- format saved data for readability
- improve error reporting for invalid habit keys
- add type hints to CLI functions
- remove unused dependency
- add pytest-based CI and two basic tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68532794fcfc832d92c0a65a74c14285