### PR TITLE
Add debug flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ pip install -r requirements.txt
 
 # Run the app
 python habit.py show
+
+# Run the web UI (add --debug or set DEBUG=1 to enable Flask debugging)
+python app.py [--debug]
 ```
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -179,4 +179,15 @@ def settings():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    import argparse
+    parser = argparse.ArgumentParser(description="Run the Flask web UI")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable Flask debug mode (overrides $DEBUG)",
+    )
+    args = parser.parse_args()
+
+    env_debug = os.getenv("DEBUG", "").lower() in {"1", "true", "yes"}
+    debug = args.debug or env_debug
+    app.run(debug=debug)


### PR DESCRIPTION
## Summary
- add CLI arg and DEBUG env var to toggle Flask debug mode
- document debug options in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685379119440832d9780ae325dbd06aa