### PR TITLE
Add tasks document

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,7 @@ This is a lightweight, ADHD-friendly habit and mood tracker designed to be fast,
 * [ ] PyPI packaging and `pipx` support
 * [ ] One-file Windows/Mac installer (PyInstaller)
 * [ ] Final polish + demo GIF
+For a detailed list of ongoing tasks, see [tasks.md](tasks.md).
 
 ---
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,20 @@
+# 📋 Task List
+
+The following improvements were suggested for the project. Each item below represents a task to be completed.
+
+- [ ] **Improve path handling in `habit.py`**
+  - Use `pathlib.Path` for better cross-platform support
+  - Allow the data file path to be overridden via an environment variable
+- [ ] **Add docstrings and type hints**
+  - Document functions like `get_week_range`, `calculate_habit_stats`, and `load_config`
+  - Add type hints across the codebase
+- [ ] **Increase test coverage**
+  - Add tests for the `mood` command and Flask routes
+  - Cover edge cases like malformed JSON and invalid mood scores
+- [ ] **Refactor common functionality**
+  - Centralize data load/save logic in a shared module used by both CLI and web
+- [ ] **Packaging and configuration**
+  - Provide a `setup.cfg` or setup script for installation
+  - Document how to customize habits or the data path in `README.md`
+- [ ] **Review web assets**
+  - Self-host external libraries referenced by the service worker or adjust caching strategy


### PR DESCRIPTION
## Summary
- add a new tasks document listing improvement ideas
- link tasks from the architecture notes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537bc5beb8832d8ff3b1bfdff5ac3c