### PR TITLE
Persist dark mode

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -14,7 +14,7 @@
     }
   </script>
 </head>
-<body x-data="{ dark: false }" :class="{ 'dark': dark }">
+<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'false') }" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
   <header>
     <h1>📈 Analytics</h1>
     <div class="controls">

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,11 +15,11 @@
   </script>
 </head>
 <body x-data="{
-  dark: false,
+  dark: JSON.parse(localStorage.getItem('darkMode') || 'false'),
   mood: {{ mood or 3 }},
   showModal: false,
   form: { habit: '', label: '', duration: 15, note: '' }
-}" :class="{ 'dark': dark }">
+}" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
 
   <header>
     <h1>🌿 habit-track (Web UI)</h1>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,7 +13,7 @@
     }
   </script>
 </head>
-<body x-data="{ dark: false }" :class="{ 'dark': dark }">
+<body x-data="{ dark: JSON.parse(localStorage.getItem('darkMode') || 'false') }" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
   <header>
     <h1>⚙️ Settings</h1>
     <div class="controls">


### PR DESCRIPTION
## Summary
- persist dark mode preference in `localStorage`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685412559298832da98a0d9146846ac5