### PR TITLE
Fix service worker cache entries

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -3,7 +3,6 @@ const urlsToCache = [
   "/",
   "/analytics",
   "/settings",
-  "/export",
   "/static/styles.css",
   "/static/manifest.json",
   "/static/icons/icon-192.png",


### PR DESCRIPTION
## Summary
- ensure offline cache excludes `/export`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685418d4fda0832da42a8fd24ece6642