### PR TITLE
Fix UX and data sync issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,18 @@ def log_habit(habit):
         "note": request.form.get("note", ""),
     }
     save_data(data)
-    return ("", 204)
+    # Return updated grid HTML so HTMX can swap it in
+    config = load_config()
+    week = get_week_range()
+    grid = render_template(
+        "_habit_row.html",
+        habits=config,
+        data=data,
+        week=week,
+        today=today,
+    )
+    html = f"<div id=\"habit-grid\">{grid}</div>"
+    return html
 
 
 @app.route("/mood", methods=["POST"])
@@ -119,7 +130,7 @@ def log_mood():
     today = str(datetime.date.today())
     data.setdefault(today, {})["mood"] = score
     save_data(data)
-    return ("", 204)
+    return {"status": "ok", "score": score}
 
 
 @app.route("/export")

--- a/static/styles.css
+++ b/static/styles.css
@@ -58,6 +58,11 @@ button.done {
 .theme-toggle {
   background: #eee;
 }
+body.dark .theme-toggle {
+  background: #444;
+  color: #e0e0e0;
+  border-color: #666;
+}
 
 a.button {
   color: #222;
@@ -127,6 +132,9 @@ body.dark .tile {
 /* Mood Block */
 .mood-block {
   margin-top: 2em;
+}
+.save-indicator {
+  margin-left: 0.5em;
 }
 
 /* Modal Styles */

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,7 @@
 <body x-data="{
   dark: JSON.parse(localStorage.getItem('darkMode') || 'false'),
   mood: {{ mood or 3 }},
+  moodSaved: false,
   showModal: false,
   form: { habit: '', label: '', duration: 15, note: '' }
 }" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
@@ -54,9 +55,11 @@
   <!-- Mood Tracker -->
   <section class="mood-block">
     <h2>🧠 Mood Score</h2>
-    <form hx-post="/mood" hx-trigger="change" hx-target="this" hx-swap="none">
+    <form hx-post="/mood" hx-trigger="change" hx-target="this" hx-swap="none"
+          hx-on="htmx:afterRequest: moodSaved = true; setTimeout(() => moodSaved = false, 1000)">
       <input type="range" name="score" min="1" max="5" x-model="mood">
       <output x-text="mood" style="margin-left: 0.5em;"></output>
+      <span x-show="moodSaved" class="save-indicator" x-transition>✅</span>
     </form>
   </section>
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -29,7 +29,8 @@ def test_post_log_route(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:
         resp = client.post("/log/med", data={"duration": "15", "note": "test"})
-        assert resp.status_code == 204
+        assert resp.status_code == 200
+        assert "<table" in resp.get_data(as_text=True)
         data = read_json(flask_app_module.DATA_FILE)
         today = str(datetime.date.today())
         assert data[today]["med"]["duration"] == 15
@@ -42,7 +43,9 @@ def test_post_mood_route(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:
         resp = client.post("/mood", data={"score": "3"})
-        assert resp.status_code == 204
+        assert resp.status_code == 200
+        assert resp.is_json
+        assert resp.get_json()["score"] == 3
         data = read_json(flask_app_module.DATA_FILE)
         today = str(datetime.date.today())
         assert data[today]["mood"] == 3


### PR DESCRIPTION
## Summary
- update `/log/<habit>` endpoint to return updated grid HTML
- send confirmation JSON in `/mood` route
- show mood save indicator and add Alpine state
- tweak dark mode `.theme-toggle`
- adjust tests for new responses

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68541dcd51a4832d9c52c557c4e9d982