### PR TITLE
Disable PWA manifest and service worker in Codespaces

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,13 +6,13 @@
   <script src="{{ url_for('static', filename='htmx.min.js') }}"></script>
   <script src="{{ url_for('static', filename='alpine.min.js') }}" defer></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-  <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
-  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
-  <script>
-    if ("serviceWorker" in navigator) {
+  {% if 'github.dev' not in request.host %}
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <script>
       navigator.serviceWorker.register("/static/service-worker.js");
-    }
-  </script>
+    </script>
+  {% endif %}
+  <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg">
 </head>
 <body x-data="{
   dark: JSON.parse(localStorage.getItem('darkMode') || 'false'),


### PR DESCRIPTION
## Summary
- conditionally load the manifest and service worker only when not in GitHub Codespaces

## Testing
- `pytest -q`
- `curl http://localhost:5000/static/manifest.json | head` (with Flask running)

------
https://chatgpt.com/codex/tasks/task_e_685425f70988832d9443a2c14bfce22f