### PR TITLE
Fix POST to /log/<habit> with date parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,12 +113,17 @@ def index():
 @app.route("/log/<habit>", methods=["POST"])
 def log_habit(habit):
     data = load_data()
-    today = str(datetime.date.today())
-    data.setdefault(today, {})[habit] = {
-        "duration": int(request.form.get("duration", 1)),
-        "note": request.form.get("note", ""),
-    }
-    save_data(data)
+    target_date = request.form.get("date", str(datetime.date.today()))
+    if request.args.get("delete") == "1":
+        data.get(target_date, {}).pop(habit, None)
+        save_data(data)
+    else:
+        data.setdefault(target_date, {})[habit] = {
+            "duration": int(request.form.get("duration", 1)),
+            "note": request.form.get("note", ""),
+        }
+        save_data(data)
+
     config = load_config()
     week = get_week_range()
     grid = render_template(
@@ -126,10 +131,9 @@ def log_habit(habit):
         habits=config,
         data=data,
         week=week,
-        today=today,
+        today=str(datetime.date.today()),
     )
-    html = f'<div id="habit-grid">{grid}</div>'
-    return html
+    return f'<div id="habit-grid">{grid}</div>'
 
 
 @app.route("/mood", methods=["POST"])

--- a/templates/_habit_row.html
+++ b/templates/_habit_row.html
@@ -24,15 +24,16 @@
                   {% endif %}
                   <button
                     class="edit-button"
-                    @click.prevent="
-                      showModal = true;
-                      form.habit = '{{ key }}';
-                      form.label = '{{ label }}';
-                      form.duration = '{{ entry.duration }}';
-                      form.note = `{{ entry.note | e }}`;
-                    "
-                    title="Edit entry"
-                  >🖉</button>
+                  @click.prevent="
+                    showModal = true;
+                    form.habit = '{{ key }}';
+                    form.label = '{{ label }}';
+                    form.duration = '{{ entry.duration }}';
+                    form.note = `{{ entry.note | e }}`;
+                    form.date = '{{ day|string }}';
+                  "
+                  title="Edit entry"
+                >🖉</button>
                 </div>
               {% else %}
                 <button
@@ -42,6 +43,7 @@
                     form.label = '{{ label }}';
                     form.duration = localStorage.getItem(`${form.habit}_duration`) || {{ info.default_duration }};
                     form.note = localStorage.getItem(`${form.habit}_note`) || '';
+                    form.date = '{{ day|string }}';
                   "
                   class="log-button"
                 >Log</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -88,6 +88,7 @@
         localStorage.setItem(`${form.habit}_note`, form.note);
         showModal = false
       ">
+        <input type="hidden" name="date" :value="form.date">
         <label>Duration (minutes):</label>
         <input type="number" name="duration" x-model="form.duration" min="1" required>
         <label>Note:</label>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -39,6 +39,22 @@ def test_post_log_route(tmp_path):
         restore(orig_data, orig_config)
 
 
+def test_post_log_custom_date(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        custom_date = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+        resp = client.post(
+            "/log/med",
+            data={"duration": "20", "note": "yesterday", "date": custom_date},
+        )
+        assert resp.status_code == 200
+        data = read_json(flask_app_module.DATA_FILE)
+        assert data[custom_date]["med"]["duration"] == 20
+        assert data[custom_date]["med"]["note"] == "yesterday"
+    finally:
+        restore(orig_data, orig_config)
+
+
 def test_post_mood_route(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- handle custom dates and deletions when logging habits
- track the selected date in the modal form
- update habit grid buttons to include the date
- test posting a log entry for a custom date

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544ccc1dd4832d8a211b6bc1f57c6a