### PR TITLE
Fix mood POST visual feedback

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -179,6 +179,7 @@ body.dark .tile {
 }
 .save-indicator {
   margin-left: 0.5em;
+  transition: opacity 0.3s ease;
 }
 
 /* Modal Styles */

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -69,6 +69,18 @@ def test_post_mood_route(tmp_path):
         restore(orig_data, orig_config)
 
 
+def test_log_mood(tmp_path):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        res = client.post("/mood", data={"score": "4"})
+        assert res.status_code == 200
+        assert res.is_json
+        assert res.get_json()["status"] == "ok"
+        assert res.get_json()["score"] == 4
+    finally:
+        restore(orig_data, orig_config)
+
+
 def test_homepage(tmp_path):
     client, orig_data, orig_config = make_client(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- add CSS transition to mood save indicator
- add regression test for /mood POST

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544e393054832d8061c257ae0f4f37