### PR TITLE
Add mood analytics and summary

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -177,6 +177,9 @@ body.dark .tile {
 .mood-block {
   margin-top: 2em;
 }
+.mood-summary {
+  margin-top: 1em;
+}
 .save-indicator {
   margin-left: 0.5em;
   transition: opacity 0.3s ease;

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -76,6 +76,35 @@
         </script>
       </div>
     {% endfor %}
+
+    <div class="chart-block">
+      <h3>Mood Over Time</h3>
+      <canvas id="mood-chart"></canvas>
+      <script>
+        const moodSeries = {{ mood_series | tojson }};
+        const ctx = document.getElementById('mood-chart').getContext('2d');
+        const lineColor = document.body.classList.contains('dark') ? '#ffffff' : '#222222';
+        new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: moodSeries.map(p => p.date),
+            datasets: [{
+              label: 'Mood',
+              data: moodSeries.map(p => p.score),
+              tension: 0.3,
+              fill: false,
+              borderColor: lineColor,
+              backgroundColor: lineColor
+            }]
+          },
+          options: {
+            responsive: true,
+            scales: { y: { beginAtZero: true, max: 5 } },
+            plugins: { legend: { display: false } }
+          }
+        });
+      </script>
+    </div>
   </section>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,8 @@
   mood: {{ mood or 3 }},
   moodSaved: false,
   showModal: false,
-  form: { habit: '', label: '', duration: 15, note: '' }
+  form: { habit: '', label: '', duration: 15, note: '' },
+  moodStats: {{ mood_stats | tojson }}
 }" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
 
   {% if debug %}
@@ -77,6 +78,13 @@
       <output x-text="mood" style="margin-left: 0.5em;"></output>
       <span x-show="moodSaved" class="save-indicator" x-transition>✅</span>
     </form>
+
+    <div class="mood-summary tile">
+      <h3>📋 Mood Summary</h3>
+      <p>7-day Avg: <strong x-text="moodStats.weekly_avg.toFixed(1)"></strong></p>
+      <p>30-day Avg: <strong x-text="moodStats['30d_avg'].toFixed(1)"></strong></p>
+      <p>Overall Avg: <strong x-text="moodStats.overall_avg.toFixed(1)"></strong></p>
+    </div>
   </section>
 
   <!-- Modal -->


### PR DESCRIPTION
## Summary
- calculate mood statistics and serve them via routes
- render mood summary card on home page
- show mood line chart on analytics page
- style mood summary tile
- test mood averages and new UX

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685450566c68832d87cca5f8ada4126f