### PR TITLE
Bind Flask to 0.0.0.0 for Render deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,4 +288,5 @@ if __name__ == "__main__":
     app.config["APP_MODE"] = args.mode
     app.config["PWA_ENABLED"] = args.mode == "prod"
 
-    app.run(debug=debug)
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- ensure the Flask server listens on the port Render sets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685460d55360832d815208f363fac0ce