### PR TITLE
Fix Alpine scope and add mood chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # habit-track-cli
 [![CI](https://github.com/jake0lawrence/habit-track-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/jake0lawrence/habit-track-cli/actions)
+[![Live on Render](https://img.shields.io/badge/%E2%9C%85%20LIVE%20on%20Render-00c7b7?style=flat-square&logo=render&logoColor=white)](https://habit-track-cli.onrender.com)
 
 Tiny, ADHD‑friendly habit & mood tracker built with [Typer](https://typer.tiangolo.com/) and [Rich](https://rich.readthedocs.io/).
 

--- a/app.py
+++ b/app.py
@@ -223,7 +223,13 @@ def analytics():
     week = get_week_range()
     data = backend.get_range(str(week[0]), str(week[-1]))
     config = load_config()
-    mood_series = calculate_mood_stats(backend.load_all())["series"]
+    all_data = backend.load_all()
+    mood_series = [
+        {"date": d, "score": entry["mood"]}
+        for d, entry in all_data.items()
+        if "mood" in entry
+    ]
+    mood_series.sort(key=lambda x: x["date"])
 
     chart_data = []
     for key, info in config.items():

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -78,29 +78,26 @@
     {% endfor %}
 
     <div class="chart-block">
-      <h3>Mood Over Time</h3>
+      <h3>🧠 Mood Score</h3>
       <canvas id="mood-chart"></canvas>
       <script>
-        const moodSeries = {{ mood_series | tojson }};
-        const ctx = document.getElementById('mood-chart').getContext('2d');
-        const lineColor = document.body.classList.contains('dark') ? '#ffffff' : '#222222';
-        new Chart(ctx, {
+        new Chart(document.getElementById("mood-chart"), {
           type: 'line',
           data: {
-            labels: moodSeries.map(p => p.date),
+            labels: {{ mood_series | map(attribute='date') | list | tojson }},
             datasets: [{
-              label: 'Mood',
-              data: moodSeries.map(p => p.score),
-              tension: 0.3,
+              label: 'Mood Score',
+              data: {{ mood_series | map(attribute='score') | list | tojson }},
+              borderColor: '#f56565',
               fill: false,
-              borderColor: lineColor,
-              backgroundColor: lineColor
+              tension: 0.3
             }]
           },
           options: {
             responsive: true,
-            scales: { y: { beginAtZero: true, max: 5 } },
-            plugins: { legend: { display: false } }
+            scales: {
+              y: { min: 0, max: 5, title: { display: true, text: 'Score (1\u20135)' } }
+            }
           }
         });
       </script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,9 +24,11 @@
   mood: {{ mood or 3 }},
   moodSaved: false,
   showModal: false,
-  form: { habit: '', label: '', duration: 15, note: '' },
+  form: { habit: '', label: '', duration: 15, note: '', date: '' },
   moodStats: {{ mood_stats | tojson }}
-}" x-init="$watch('dark', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': dark }">
+}"
+  x-init="$watch('dark', val => localStorage.setItem('darkMode', val))"
+  :class="{ 'dark': dark }">
 
   {% if debug %}
   <div class="debug-banner">


### PR DESCRIPTION
## Summary
- ensure Alpine state persists across dynamic updates
- show mood trends on /analytics
- highlight live deployment with a README badge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685463d1237c832da49675e585acdb96