### PR TITLE
Add AI-powered journaling feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rich>=13.7
 pytest>=8.2
 flask>=2.3
 psycopg2-binary>=2.9
+openai>=1.0

--- a/templates/journal.html
+++ b/templates/journal.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>🧠 AI Journal – habit-track</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header><h1>🧠 Mood Journal</h1></header>
+  <pre style="white-space: pre-wrap;">{{ prompt }}</pre>
+
+  <form method="POST" action="/journal-entry">
+    <textarea name="entry" rows="10" style="width: 100%;" placeholder="Write your thoughts..."></textarea>
+    <button type="submit" class="button">💾 Save Entry</button>
+  </form>
+</body>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -152,3 +152,16 @@ def test_pwa_toggle(tmp_path):
     finally:
         flask_app_module.app.config["PWA_ENABLED"] = original
         restore(orig_data, orig_config)
+
+
+def test_journal_route(tmp_path, monkeypatch):
+    client, orig_data, orig_config = make_client(tmp_path)
+    try:
+        def fake_enrich(prompt):
+            return "Prompt"
+        monkeypatch.setattr(flask_app_module, "enrich_prompt_with_ai", fake_enrich)
+        res = client.get("/journal")
+        assert res.status_code == 200
+        assert b"Mood Journal" in res.data
+    finally:
+        restore(orig_data, orig_config)


### PR DESCRIPTION
## Summary
- enable GPT-based journaling
- save journal entries to `journal.md`
- add journal route with template
- include OpenAI in requirements
- test new /journal route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685466b104a8832d85b367c9bee386af