### PR TITLE
Add journaling history and AI model toggle

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,8 @@ services:
   envVars:
     - key: APP_MODE
       value: prod
+    - key: AI_MODEL
+      value: gpt-3.5-turbo
     # Uncomment if using Postgres
     # - key: DATABASE_URL
     #   fromDatabase:

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,6 +42,7 @@
       <button @click="dark = !dark" class="theme-toggle" x-text="dark ? '🌗 Light Mode' : '🌑 Dark Mode'"></button>
       <a href="/export" class="button">📥 Export as CSV</a>
       <a href="/analytics" class="button">📊 Analytics</a>
+      <a href="/journal-history" class="button">📜 View Past Journals</a>
       <a href="/settings" class="button">⚙️ Settings</a>
       <button onclick="window.print()" class="button">🖨️ Print View</button>
     </div>

--- a/templates/journal.html
+++ b/templates/journal.html
@@ -13,5 +13,9 @@
     <textarea name="entry" rows="10" style="width: 100%;" placeholder="Write your thoughts..."></textarea>
     <button type="submit" class="button">💾 Save Entry</button>
   </form>
+  <p>
+    <a href="/download-journal?format=txt" class="button">📄 Download .txt</a>
+    <a href="/download-journal?format=zip" class="button">🗜️ Download .zip</a>
+  </p>
 </body>
 </html>

--- a/templates/journal_history.html
+++ b/templates/journal_history.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>📜 Journal History</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+<h1>📜 Journal History</h1>
+{% if entries %}
+  {% for entry in entries %}
+    <div class="tile">
+      <h3>{{ entry.date }}</h3>
+      <pre>{{ entry.text }}</pre>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>No entries found.</p>
+{% endif %}
+</body>
+</html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -26,6 +26,7 @@
     <div class="controls">
       <a href="/" class="button">← Back</a>
       <button @click="dark = !dark" class="theme-toggle" x-text="dark ? '🌗 Light Mode' : '🌑 Dark Mode'"></button>
+      <a href="/journal-history" class="button">📜 View Past Journals</a>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add `/download-journal` route and download links
- allow selecting GPT model via `AI_MODEL` env var
- display journal history from `journal.md`
- navigation link for journal history
- tests for new routes and model toggle

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685469d51794832dafab92e7bc50401f