### PR TITLE
Fix CLI test compatibility and Playwright selectors

### DIFF
--- a/e2e/save.spec.ts
+++ b/e2e/save.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test('log habit end-to-end', async ({ page }) => {
   await page.goto(process.env.BASE_URL || 'http://localhost:5000');
-  await page.getByRole('button', { name: 'Log', exact: true }).click();
-  await page.getByLabel('Duration (minutes):').fill('7');
+  await page.getByTestId('log-med').click();
+  await page.locator('input[name="duration"]').fill('7');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page.getByText('✅ 7 min')).toBeVisible();
 });

--- a/templates/_habit_row.html
+++ b/templates/_habit_row.html
@@ -32,6 +32,7 @@
 
                 <button
                   class="edit-button"
+                  data-testid="edit-{{ key }}"
                   @click.prevent="
                     showModal = true;
                     form = {
@@ -49,6 +50,7 @@
             {% else %}
               <button
                 class="log-button"
+                data-testid="log-{{ key }}"
                 @click.prevent="
                   showModal = true;
                   form = {

--- a/tests/test_habit.py
+++ b/tests/test_habit.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(ROOT))
 
 import habit
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def test_load_data_missing_file(tmp_path):


### PR DESCRIPTION
## Summary
- add data-testid attributes to log/edit buttons
- update Playwright test to click using data-testid
- drop `mix_stderr` arg from CliRunner for newer click

## Testing
- `pytest -q`
- `npx playwright test` *(fails: Test was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68559cff3364832da3e893e449a42448