### PR TITLE
Handle toasts via Alpine init

### DIFF
--- a/e2e/save.spec.ts
+++ b/e2e/save.spec.ts
@@ -14,4 +14,9 @@ test('log habit end-to-end', async ({ page }) => {
 
   // Grid should now show the new entry
   await expect(page.getByText('✅ 7 min')).toBeVisible();
+
+  // Toast should briefly appear
+  const toast = page.locator('.toast');
+  await expect(toast).toContainText('Saved');
+  await expect(toast).toHaveClass(/show/);
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
   <script id="mood-data" type="application/json">{{ mood_stats | tojson }}</script>
 {% endblock %}
 
-{% block body_attrs %}x-data="getAppState()" x-init="$watch('dark', v => localStorage.setItem('darkMode', v))" :class="{ dark }"{% endblock %}
+{% block body_attrs %}x-data="getAppState()" x-init="init(); $watch('dark', v => localStorage.setItem('darkMode', v))" :class="{ dark }"{% endblock %}
 
 {% block content %}
   {# ───── Header config for the partial ───── #}
@@ -116,26 +116,25 @@
           this.toast.error   = isError;
           this.toast.show    = true;
           setTimeout(() => this.toast.show = false, 3000);
+        },
+
+        init() {
+          htmx.on('htmx:afterSwap', e => {
+            if (!e.detail || !e.detail.target) return;
+            if (e.detail.target.id === 'habit-grid') {
+              this.showToast('Saved ✔️');
+            }
+          });
+
+          htmx.on('htmx:responseError', e => {
+            if (e.detail) {
+              const code = e.detail.xhr.status;
+              this.showToast(`Save failed (${code})`, true);
+            }
+          });
         }
       }
     }
   </script>
 
-  <script>
-    /* Success toast after habit grid swap */
-    htmx.on('htmx:afterSwap', e => {
-      if (!e.detail || !e.detail.target) return;
-      if (e.detail.target.id === 'habit-grid') {
-        document.body.__x.$data.showToast('Saved ✔️');
-      }
-    });
-
-    /* Error toast for non-200 responses */
-    htmx.on('htmx:responseError', e => {
-      if (document.body.__x && e.detail) {
-        const code = e.detail.xhr.status;
-        document.body.__x.$data.showToast(`Save failed (${code})`, true);
-      }
-    });
-  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wire up HTMX event handlers in Alpine `init()`
- run `init()` automatically on `<body>`
- test that success toast appears after saving a habit

## Testing
- `pytest -q`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686896c145f0832dbf9b36d9600dffd5