### PR TITLE
Stub user methods for JSON backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt  # installs Flask-Login & passlib too
 # ⬇️ Optional: enable AI journal prompts
 export OPENAI_API_KEY=sk-********************************
 # Choose config via APP_MODE (dev | prod)
-export APP_MODE=dev
+export APP_MODE=dev  # uses local JSON storage (no accounts)
 
 python app.py   # auto-reload in dev mode
 ````
@@ -63,10 +63,11 @@ Open [http://localhost:5000](http://localhost:5000) & start tracking.
 
 ## 🔐 Sign Up & Log In
 
-The web UI now supports accounts. Head to `/signup` to create a user and then
-log in via `/login`. Passwords are hashed with **passlib[bcrypt]** and sessions
-are managed by **Flask-Login**. Existing data from older versions is migrated to
-the first account automatically.
+The web UI now supports accounts *(SQLite/Postgres only)*. Head to `/signup` to
+create a user and then log in via `/login`. Passwords are hashed with
+**passlib[bcrypt]** and sessions are managed by **Flask-Login**. Existing data
+from older versions is migrated to the first account automatically. JSON-based
+`APP_MODE=dev` skips this feature.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ htmx swaps only the relevant fragment on each page, so full reloads are rare.
 | ID  | Goal                      | Success Signal                               |
 | --- | ------------------------- | -------------------------------------------- |
 | G‑1 | **Log a habit in < 10 s** | One click/tap + Save toast                   |
-| G‑2 | **Own the data**          | JSON dev / SQLite prod; one‑click export     |
+| G‑2 | **Own the data**          | JSON dev (no accounts) / SQLite prod; one‑click export     |
 | G‑3 | **Zero downtime offline** | PWA manifests + service‑worker cache         |
 | G‑4 | **Reliable Save**         | Static `/log` endpoint, toast shows ✔️       |
 | G‑5 | **Guided reflection**     | GPT‑generated prompt when mood logged        |
@@ -52,7 +52,7 @@ htmx swaps only the relevant fragment on each page, so full reloads are rare.
 | Styling           | Vanilla CSS + dark‑mode class             |  Lightweight           |
 | AI Integration    | OpenAI GPT‑4o via `/journal-prompt`       | Generates daily prompt |
 | PWA               | Workbox‑generated service worker          | Offline‑first          |
-| Persistence       | JSON (dev) ➜ SQLite or Postgres (prod)    | Own data               |
+| Persistence       | JSON (dev, no accounts) ➜ SQLite or Postgres (prod)    | Own data               |
 | Tests             | **Pytest** (unit) • **Playwright** (e2e)  | CI coverage            |
 | Optional CLI      | Typer + Rich (legacy)                     | Terminal lovers        |
 

--- a/storage.py
+++ b/storage.py
@@ -66,6 +66,28 @@ class JSONBackend:
         series.sort(key=lambda x: x["date"])
         return series
 
+    # --- account helpers -------------------------------------------------
+    def create_user(self, email, password_hash):
+        """Unsupported helper for parity with DB backends."""
+        raise NotImplementedError(
+            "JSON backend does not support user accounts. "
+            "Run with APP_MODE=prod for SQLite/Postgres."
+        )
+
+    def get_user(self, user_id):
+        """Unsupported helper for parity with DB backends."""
+        raise NotImplementedError(
+            "JSON backend does not support user accounts. "
+            "Run with APP_MODE=prod for SQLite/Postgres."
+        )
+
+    def get_user_by_email(self, email):
+        """Unsupported helper for parity with DB backends."""
+        raise NotImplementedError(
+            "JSON backend does not support user accounts. "
+            "Run with APP_MODE=prod for SQLite/Postgres."
+        )
+
 
 class SQLiteBackend:
     def __init__(self, db_path="data/habits.db"):


### PR DESCRIPTION
## Summary
- add account helper stubs to `JSONBackend`
- document that dev mode uses JSON without account support

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a08a731c832da105e7be869950ab